### PR TITLE
NULL macro should be defined as 0 to comply with C99 standard

### DIFF
--- a/src/support/libumps/const.h
+++ b/src/support/libumps/const.h
@@ -44,7 +44,7 @@
 #define HIDDEN          static
 #define EOS             '\0'
 
-#define NULL            ((void *)0xFFFFFFFF)
+#define NULL            ((void *)0)
 
 /* device interrupts */
 #define DISKINT         3


### PR DESCRIPTION
While not necessarily 0, the NULL pointer value should evaluate as equal to 0, and in general as a false value. With NULL defined as `0xFFFFFFFF`, checks like these fail:

```
if (NULL) {
// This should be false but isn't in uMPS3
}
if (NULL == 0) {
// This should be true but isn't in uMPS3
}
```